### PR TITLE
Add development environment setup (AGENTS.md + router.php)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+This is **SuiteCRM 7.14.6**, a PHP-based open-source CRM application (LAMP stack). It requires PHP 8.1+, MariaDB/MySQL, and Composer for dependencies.
+
+### Services
+
+| Service | Command | Notes |
+|---------|---------|-------|
+| Web server | `php -d display_errors=0 -d error_reporting="E_ALL & ~E_DEPRECATED & ~E_STRICT" -S localhost:8080 /workspace/router.php` | Uses `router.php` to handle URL rewriting (API routes, static files) since PHP's built-in server doesn't support `.htaccess` |
+| MariaDB | `sudo service mariadb start` | Must be started before the web server; database `suitecrm` with root access (no password) |
+
+### Running Tests
+
+- **PHPUnit (unit tests):** `./vendor/bin/phpunit --configuration ./tests/phpunit.xml.dist ./tests/unit/phpunit/lib --no-coverage`
+- **PHPUnit (module tests):** `./vendor/bin/phpunit --configuration ./tests/phpunit.xml.dist ./tests/unit/phpunit/modules/<ModuleName> --no-coverage`
+- **Codeception (acceptance/API):** `./vendor/bin/codecept run` (requires full web server + database setup)
+- **Note:** Running all module tests at once hits a fatal error in `include/Imap/ImapHandlerFake.php` due to a PHP 8.1 interface incompatibility. Run specific module test directories to avoid this.
+
+### Lint / Static Analysis
+
+- **php-cs-fixer:** `PHP_CS_FIXER_IGNORE_ENV=1 ./vendor/bin/php-cs-fixer fix --dry-run --diff` (requires `PHP_CS_FIXER_IGNORE_ENV=1` for PHP 8.1+)
+- **PHPStan:** `./vendor/bin/phpstan analyse --memory-limit=512M lib/` (no phpstan.neon config exists; pass directories explicitly)
+
+### Authentication
+
+- **Web login:** POST to `index.php` with fields `user_name`, `username_password` (note: field name is `username_password`, not `user_password`), `module=Users`, `action=Authenticate`
+- **API (JSON API v8):** OAuth2 password grant at `/Api/access_token` with client_id `suitecrm_client`, client_secret `secret`, username `admin`, password `admin123`
+- **Password hashing:** SuiteCRM uses `password_hash(strtolower(md5($plaintext)), PASSWORD_DEFAULT)` — to reset a password in the DB, generate the hash accordingly
+- **OAuth2 client secret:** Stored as `hash('sha256', $clientSecret)` in the `oauth2clients` table
+
+### Key Gotchas
+
+- The `router.php` file in the repo root is required for the PHP built-in dev server. It routes `/Api/*` requests to `Api/index.php` and serves static files directly.
+- OAuth2 keys must exist at `Api/V8/OAuth2/private.key` and `Api/V8/OAuth2/public.key` (generated with `openssl genrsa` / `openssl rsa -pubout`).
+- The `config_si.php` file triggers silent installation mode — remove it after install is complete to prevent re-running the installer.
+- MariaDB root user must use `mysql_native_password` or empty password for PHP to connect without socket auth issues.

--- a/router.php
+++ b/router.php
@@ -1,0 +1,34 @@
+<?php
+$uri = $_SERVER['REQUEST_URI'];
+$path = parse_url($uri, PHP_URL_PATH);
+
+// API routes
+if (preg_match('#^/Api/access_token#', $path) || preg_match('#^/Api/V8/#', $path)) {
+    $_SERVER['SCRIPT_NAME'] = '/Api/index.php';
+    require __DIR__ . '/Api/index.php';
+    return true;
+}
+
+// Deprecated API routes
+if (preg_match('#^/api/(.*)#', $path)) {
+    require __DIR__ . '/lib/API/public/index.php';
+    return true;
+}
+
+// JS language cache
+if (preg_match('#^/cache/jsLanguage/(..)_(..).js$#', $path, $m)) {
+    $_GET['entryPoint'] = 'jslang';
+    $_GET['modulename'] = 'app_strings';
+    $_GET['lang'] = $m[1] . '_' . $m[2];
+    require __DIR__ . '/index.php';
+    return true;
+}
+
+// Static files
+if (file_exists(__DIR__ . $path) && !is_dir(__DIR__ . $path)) {
+    return false;
+}
+
+// Default to index.php
+require __DIR__ . '/index.php';
+return true;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Adds development environment configuration files for Cursor Cloud agents:
- `AGENTS.md`: Contains cloud-agent-specific instructions including service startup, testing, linting, and authentication details
- `router.php`: URL rewriting script for PHP's built-in development server (handles API routes and static files since `.htaccess` is not supported by the built-in server)

## Motivation and Context

These files enable cloud agents to quickly set up and run the SuiteCRM development environment without needing Apache/Nginx, and provide documentation about non-obvious gotchas (password hashing, OAuth2 client setup, IMAP test compatibility issues, etc.)

## How To Test This

1. Start MariaDB: `sudo service mariadb start`
2. Install dependencies: `composer install`
3. Start dev server: `php -d display_errors=0 -d error_reporting="E_ALL & ~E_DEPRECATED & ~E_STRICT" -S localhost:8080 /workspace/router.php`
4. Access http://localhost:8080 - should show login page
5. Verify API works: `curl -X POST http://localhost:8080/Api/access_token -H "Content-Type: application/json" -d '{"grant_type":"password","client_id":"suitecrm_client","client_secret":"secret","username":"admin","password":"admin123"}'`

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

### Final checklist
- [x] My code follows the code style of this project found [here](https://docs.suitecrm.com/community/contributing-code/coding-standards/).
- [ ] My change requires a change to the documentation.
- [x] I have read the [**How to Contribute**](https://docs.suitecrm.com/community/contributing-code/) guidelines.

### Demo

[suitecrm_create_account_demo.mp4](https://cursor.com/agents/bc-1bd900d3-8815-4f2d-ab43-f31246ad65fa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsuitecrm_create_account_demo.mp4)

[SuiteCRM Dashboard after login](https://cursor.com/agents/bc-1bd900d3-8815-4f2d-ab43-f31246ad65fa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsuitecrm_dashboard.webp)
[Contacts list showing created contact](https://cursor.com/agents/bc-1bd900d3-8815-4f2d-ab43-f31246ad65fa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsuitecrm_contacts_list.webp)
[Account detail view after creation](https://cursor.com/agents/bc-1bd900d3-8815-4f2d-ab43-f31246ad65fa/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsuitecrm_account_created.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1bd900d3-8815-4f2d-ab43-f31246ad65fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1bd900d3-8815-4f2d-ab43-f31246ad65fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

